### PR TITLE
Unpin pyqt. pyqtgraph is comfortable with qt4 or qt5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -22,7 +22,8 @@ requirements:
   run:
     - python
     - numpy
-    - pyqt 4.11.*
+    # pyqtgraph works with pyqt4 or pyqt5. Don't pin it here.
+    - pyqt
 
 test:
   imports:


### PR DESCRIPTION
Reverting #1. Thanks for catching this @astaric. I've added an in-line comment
to the recipe so that when the maintainance bot comes around again it should be
apparent that the pinning PR should be rejected.